### PR TITLE
format cell, replace character in string

### DIFF
--- a/python/1_6_Functions.ipynb
+++ b/python/1_6_Functions.ipynb
@@ -291,7 +291,7 @@
    "outputs": [],
    "source": [
     "import math\n",
-    "print('Number: {},{}'.format(1, 2)) #replaces [] inside the string by the arguments of format\n",
+    "print('Number: {},{}'.format(1, 2)) #replaces {} inside the string by the arguments of format\n",
     "print('PI #{}#'.format(math.pi))\n",
     "print('PI #{:5.2f}#'.format(math.pi)) # at least 5 characters with two decimals"
    ]


### PR DESCRIPTION
Línea 294 del json.

En la celda después de explicar format, pone que se sustituye [] cuando debería ser {}